### PR TITLE
Implement {Asset,}Class<T> for unit type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,10 @@ pub trait Class<B> {
     fn apply(self, b: &mut B);
 }
 
+impl<T> Class<T> for () {
+    fn apply(self, _b: &mut T) {}
+}
+
 impl<F, B> Class<B> for F
 where
     F: FnOnce(&mut B),
@@ -129,6 +133,10 @@ impl Class<ImageBundle> for ImageBundle {
 /// Depends on an [`AssetServer`], unlike [`Class`].
 pub trait AssetClass<B> {
     fn apply(self, assets: &AssetServer, b: &mut B);
+}
+
+impl<T> AssetClass<T> for () {
+    fn apply(self, _a: &AssetServer, _b: &mut T) {}
 }
 
 impl<F, B> AssetClass<B> for F

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -115,9 +115,8 @@ pub fn text_button(
     text_style: impl AssetClass<TextStyle>,
     parent: &mut UiChildBuilder
 ) -> Entity {
-    fn c_text(_a: &AssetServer,_b: &mut TextBundle) {}       // No need to overwrite the default!
     button(class, parent, |p| {
-        text(txt, c_text, text_style, p);
+        text(txt, (), text_style, p);
     })
 }
 


### PR DESCRIPTION
Rust has some issues with cohering closures into `Class<Foo>`, seemingly because of the arguments' lifetime.

This prevents passing a `|_| {}` when the class is irrelevant. It is possible to pass `|_: &mut Foo| {}`, but it becomes very noisy. Using the unit type `()` has the advantage of not introducing any lifetimes, so it should be possible to use it when we don't want to specify a class.